### PR TITLE
Added additional_arguments option to the lvm initializer to allow for dynamic additions to BASE_ARGUMENTS

### DIFF
--- a/examples/additional_arguments.rb
+++ b/examples/additional_arguments.rb
@@ -1,0 +1,13 @@
+#!/usr/bin/ruby
+
+# Demonstration of passing additional arguments to the LVM object
+
+$: << File.dirname(__FILE__) + "/../lib"
+
+require "lvm"
+
+# List out volume groups with the --ignoreskippedcluster argument appended to the base argument list
+lvm = LVM::LVM.new(:command => "/usr/bin/sudo /sbin/lvm", :additional_arguments => "--ignoreskippedcluster")
+
+volume_groups = lvm.volume_groups
+puts volume_groups.map { |vg| vg.name }

--- a/lib/lvm.rb
+++ b/lib/lvm.rb
@@ -11,11 +11,13 @@ module LVM
     attr_reader :logical_volumes
     attr_reader :volume_groups
     attr_reader :physical_volumes
+    attr_reader :additional_arguments
 
     VALID_OPTIONS = [
       :command,
       :version,
       :debug,
+      :additional_arguments,
     ]
 
     DEFAULT_COMMAND = "/sbin/lvm"

--- a/lib/lvm/wrapper.rb
+++ b/lib/lvm/wrapper.rb
@@ -38,13 +38,16 @@ module LVM
       end
       module_function :process_line
 
-      def build_command(expected_attributes, base)
+      def build_command(expected_attributes, base, additional_arguments = [])
         opts = []
         expected_attributes.each do |a|
           opts << a[:column]
         end
 
-        return base % opts.join(",")
+        additional_arguments = [] if additional_arguments.nil?
+        additional_arguments = [additional_arguments] if additional_arguments.is_a?(String)
+
+        return base % opts.join(",") + "#{additional_arguments.empty? ? '' : ' '}#{additional_arguments.join(' ')}"
       end
       module_function :build_command
     end # module Reporting

--- a/lib/lvm/wrapper/lvs.rb
+++ b/lib/lvm/wrapper/lvs.rb
@@ -11,7 +11,7 @@ module LVM
 
       def initialize(options)
         @attributes = Attributes.load(options[:version], ATTRIBUTES_FILE)
-        @command = "#{options[:command]} #{Reporting.build_command(attributes, BASE_COMMAND)}"
+        @command = "#{options[:command]} #{Reporting.build_command(attributes, BASE_COMMAND, options[:additional_arguments])}"
       end
 
       BASE_COMMAND = "lvs #{Reporting::BASE_ARGUMENTS}"

--- a/lib/lvm/wrapper/lvsseg.rb
+++ b/lib/lvm/wrapper/lvsseg.rb
@@ -12,7 +12,7 @@ module LVM
 
       def initialize(options)
         @attributes = Attributes.load(options[:version], ATTRIBUTES_FILE)
-        @command = "#{options[:command]} #{Reporting.build_command(attributes, BASE_COMMAND)}"
+        @command = "#{options[:command]} #{Reporting.build_command(attributes, BASE_COMMAND, options[:additional_arguments])}"
       end
 
       BASE_COMMAND = "lvs #{Reporting::BASE_ARGUMENTS}"

--- a/lib/lvm/wrapper/pvs.rb
+++ b/lib/lvm/wrapper/pvs.rb
@@ -11,7 +11,7 @@ module LVM
 
       def initialize(options)
         @attributes = Attributes.load(options[:version], ATTRIBUTES_FILE)
-        @command = "#{options[:command]} #{Reporting.build_command(attributes, BASE_COMMAND)}"
+        @command = "#{options[:command]} #{Reporting.build_command(attributes, BASE_COMMAND, options[:additional_arguments])}"
       end
 
       BASE_COMMAND = "pvs #{Reporting::BASE_ARGUMENTS}"

--- a/lib/lvm/wrapper/pvsseg.rb
+++ b/lib/lvm/wrapper/pvsseg.rb
@@ -12,7 +12,7 @@ module LVM
 
       def initialize(options)
         @attributes = Attributes.load(options[:version], ATTRIBUTES_FILE)
-        @command = "#{options[:command]} #{Reporting.build_command(attributes, BASE_COMMAND)}"
+        @command = "#{options[:command]} #{Reporting.build_command(attributes, BASE_COMMAND, options[:additional_arguments])}"
       end
 
       BASE_COMMAND = "pvs #{Reporting::BASE_ARGUMENTS}"

--- a/lib/lvm/wrapper/vgs.rb
+++ b/lib/lvm/wrapper/vgs.rb
@@ -11,7 +11,7 @@ module LVM
 
       def initialize(options)
         @attributes = Attributes.load(options[:version], ATTRIBUTES_FILE)
-        @command = "#{options[:command]} #{Reporting.build_command(attributes, BASE_COMMAND)}"
+        @command = "#{options[:command]} #{Reporting.build_command(attributes, BASE_COMMAND, options[:additional_arguments])}"
       end
 
       BASE_COMMAND = "vgs #{Reporting::BASE_ARGUMENTS}"


### PR DESCRIPTION
Our site has recently encountered issues with the lvm cookbook where we need to be able to manage LVM while clustered volume groups are inaccessible. Unfortunately, we do not currently have a way to pass the `--ignoreskippedcluster` option to the lvm cookbook to allow this to work successfully.

This is a change to the chef-ruby-lvm gem to allow additional arguments to be passed to the LVM object at initialization. This change is entirely non-impactful on existing code since behavior is identical when the `additional_arguments` option is not passed.

Please let me know if this seems reasonable or if changes are necessary.

Fixes #3 

Signed-off-by: Matthew Newell <matthew.newell@cerner.com>