### PR TITLE
Use new minor version of chef-ruby-lvm-attrib

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,5 @@ gemspec
 
 group :development do
   gem "chefstyle"
+  gem "rake"
 end

--- a/chef-ruby-lvm.gemspec
+++ b/chef-ruby-lvm.gemspec
@@ -3,7 +3,7 @@ require "lvm/version"
 
 deps = {
   "open4" => ["~> 0.9", ">= 0.9.6"],
-  "chef-ruby-lvm-attrib" => ["~> 0.2"],
+  "chef-ruby-lvm-attrib" => ["~> 0.3"],
 }
 
 Gem::Specification.new do |gem|


### PR DESCRIPTION
### Description

The version of chef-ruby-lvm-attrib has gone from 0.2.x to 0.3.0. The gemspec dependency here needs to be updated

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG