### PR TITLE
Fix undefined line variable error in LVM::External

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 0.4.2
+
+- Fix undefined variable error in `LVM::External::Module`
+
 ## 0.4.1 (2022-04-25)
 
 - Use new minor version of chef-ruby-lvm-attrib

--- a/lib/lvm/external.rb
+++ b/lib/lvm/external.rb
@@ -9,7 +9,9 @@ module LVM
       output = []
       error = nil
       stat = Open4.popen4(cmd) do |pid, stdin, stdout, stderr|
-        output << line while line == stdout.gets
+        while (line = stdout.gets)
+          output << line
+        end
         error = stderr.read.strip
       end
       if stat.exited?

--- a/lib/lvm/version.rb
+++ b/lib/lvm/version.rb
@@ -1,3 +1,3 @@
 module LVM
-  VERSION = "0.4.1".freeze
+  VERSION = "0.4.2".freeze
 end


### PR DESCRIPTION
### Description

This is a regression that was introduced in commit
9e73c2832e4ab5af89353af6a57e5838e3ff566b. The change is a simple fix
to ensure the line variable is defined at the time it is accessed.

Signed-off-by: Matthew Newell <matthew.newell@cerner.com>

### Issues Resolved

Fixes #10

#### Current Behavior
```ruby
require 'lvm'
LVM::VERSION
 => "0.4.1"

lvm = LVM::LVM.new
/usr/share/rvm/gems/ruby-3.0.2/gems/chef-ruby-lvm-0.4.1/lib/lvm/external.rb:12:in `block in cmd': undefined local variable or method `line' for LVM::External:Module (NameError)
        from /usr/share/rvm/gems/ruby-3.0.2/gems/open4-0.9.6/lib/open4.rb:68:in `popen4'
        from /usr/share/rvm/gems/ruby-3.0.2/gems/chef-ruby-lvm-0.4.1/lib/lvm/external.rb:11:in `cmd'
        from /usr/share/rvm/gems/ruby-3.0.2/gems/chef-ruby-lvm-0.4.1/lib/lvm.rb:51:in `raw'
        from /usr/share/rvm/gems/ruby-3.0.2/gems/chef-ruby-lvm-0.4.1/lib/lvm.rb:68:in `userland'
        from /usr/share/rvm/gems/ruby-3.0.2/gems/chef-ruby-lvm-0.4.1/lib/lvm.rb:62:in `version'
        from /usr/share/rvm/gems/ruby-3.0.2/gems/chef-ruby-lvm-0.4.1/lib/lvm.rb:35:in `initialize'
        from (irb):3:in `new'
        from (irb):3:in `<main>'
        from /usr/share/rvm/rubies/ruby-3.0.2/lib/ruby/gems/3.0.0/gems/irb-1.3.5/exe/irb:11:in `<top (required)>'
        from /usr/share/rvm/rubies/ruby-3.0.2/bin/irb:23:in `load'
        from /usr/share/rvm/rubies/ruby-3.0.2/bin/irb:23:in `<main>'
```

#### New Behavior
```ruby
require 'lvm'
LVM::VERSION
 => "0.4.2"

lvm = LVM::LVM.new
 =>
#<LVM::LVM:0x000055f368c42190
...
```

### Check List

- [x] New functionality includes tests (N/A, no tests defined)
- [x] All tests pass (N/A, no tests defined)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG