### PR TITLE
Fix version parsing for RHEL 10 lvm2 output format

### DIFF
--- a/lib/lvm.rb
+++ b/lib/lvm.rb
@@ -59,7 +59,24 @@ module LVM
     end
 
     def version
-      /^(.*?)(-| )/.match(userland.lvm_version)[1]
+      self.class.parse_version(userland.lvm_version.to_s)
+    end
+
+    # Extracts the canonical "X.Y.Z" or "X.Y.Z(N)" version key used to look up
+    # attribute YAML files in chef-ruby-lvm-attrib, tolerating known variations
+    # in the `lvm version` output across distributions and releases.
+    #
+    # Examples:
+    #   "2.03.28(2)-RHEL10 (2024-11-04)" => "2.03.28(2)"  # classic format
+    #   "2.03.32(2-RHEL10) (2025-05-05)" => "2.03.32(2)"  # RHEL 10 format
+    #   "2.02.180(2)-RHEL7 (2018-07-20)" => "2.02.180(2)"
+    #   "2.03.40"                        => "2.03.40"     # no build suffix
+    def self.parse_version(raw)
+      m = raw.to_s.match(/(\d+\.\d+\.\d+)(?:\((\d+))?/)
+      return raw.to_s if m.nil?
+
+      # If build is captured, then return "X.Y.Z(N)" else "X.Y.Z"
+      m[2] ? "#{m[1]}(#{m[2]})" : m[1]
     end
 
     # helper methods

--- a/test/test_lvm.rb
+++ b/test/test_lvm.rb
@@ -1,0 +1,36 @@
+require "minitest/autorun"
+require_relative "../lib/lvm"
+
+class TestLVMVersionParsing < Minitest::Test
+  # Classic format used by lvm2 prior to RHEL 10.
+  def test_parses_classic_rhel_format
+    assert_equal "2.03.28(2)",
+      LVM::LVM.parse_version("2.03.28(2)-RHEL10 (2024-11-04)")
+  end
+
+  # RHEL 10 format moved the dist tag inside the build parentheses.
+  # See: https://github.com/sous-chefs/chef-ruby-lvm-attrib/issues/90
+  def test_parses_rhel10_inline_dist_format
+    assert_equal "2.03.32(2)",
+      LVM::LVM.parse_version("2.03.32(2-RHEL10) (2025-05-05)")
+  end
+
+  def test_parses_older_rhel7_style
+    assert_equal "2.02.180(2)",
+      LVM::LVM.parse_version("2.02.180(2)-RHEL7 (2018-07-20)")
+  end
+
+  def test_parses_plain_version_without_build_suffix
+    assert_equal "2.03.40",
+      LVM::LVM.parse_version("2.03.40")
+  end
+
+  def test_returns_input_unchanged_when_unparseable
+    assert_equal "garbage",
+      LVM::LVM.parse_version("garbage")
+  end
+
+  def test_handles_nil_input
+    assert_equal "", LVM::LVM.parse_version(nil)
+  end
+end


### PR DESCRIPTION
The 'lvm version' output format changed between lvm2 2.03.28 and 2.03.32:

  Before: 'LVM version: 2.03.28(2)-RHEL10 (2024-11-04)'
  After:  'LVM version: 2.03.32(2-RHEL10) (2025-05-05)'

The previous regex /^(.*?)(-| )/ truncated at the first '-', which now appears inside the parens, producing '2.03.32(2' instead of '2.03.32(2)'. This caused chef-ruby-lvm-attrib's Attributes.load to fail with ENOENT on a non-existent directory.

Replace with a tolerant parser extracted into a class method, and add the first minitest coverage to test/ for both formats plus edge cases.

Refs: sous-chefs/chef-ruby-lvm-attrib#90

### Description

The `lvm version` output format changed between lvm2 2.03.28 and 2.03.32 - the dist tag (e.g. `-RHEL10`) moved inside the build-number parentheses, for example:

| 10.0  | `LVM version: 2.03.28(2)-RHEL10 (2024-11-04)` |
| 10.1 | `LVM version: 2.03.32(2-RHEL10) (2025-05-05)` |


### Issues Resolved

https://github.com/sous-chefs/chef-ruby-lvm-attrib/issues/90


### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG
