### PR TITLE
Fix LVM version parsing for RHEL 10 output format

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 group :development do
+  gem "base64"
   gem "chefstyle"
   gem "minitest"
   gem "ostruct"

--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,7 @@ gemspec
 
 group :development do
   gem "chefstyle"
+  gem "minitest"
+  gem "ostruct"
   gem "rake"
 end

--- a/lib/lvm.rb
+++ b/lib/lvm.rb
@@ -59,7 +59,16 @@ module LVM
     end
 
     def version
-      /^(.*?)(-| )/.match(userland.lvm_version)[1]
+      self.class.parse_version(userland.lvm_version)
+    end
+
+    # Extract the canonical X.Y.Z or X.Y.Z(N) version key used by
+    # chef-ruby-lvm-attrib attribute directories.
+    def self.parse_version(raw)
+      match = raw.to_s.match(/(\d+\.\d+\.\d+)(?:\((\d+))?/)
+      return raw.to_s if match.nil?
+
+      match[2] ? "#{match[1]}(#{match[2]})" : match[1]
     end
 
     # helper methods

--- a/test/test_lvm.rb
+++ b/test/test_lvm.rb
@@ -1,0 +1,36 @@
+require "minitest/autorun"
+require_relative "../lib/lvm"
+
+class TestLVMVersionParsing < Minitest::Test
+  def test_parses_classic_rhel_format
+    assert_equal "2.03.28(2)",
+      LVM::LVM.parse_version("2.03.28(2)-RHEL10 (2024-11-04)")
+  end
+
+  def test_parses_rhel10_inline_dist_format
+    assert_equal "2.03.32(2)",
+      LVM::LVM.parse_version("2.03.32(2-RHEL10) (2025-05-05)")
+  end
+
+  def test_parses_release_suffix_outside_parentheses
+    assert_equal "2.03.32(2)",
+      LVM::LVM.parse_version("2.03.32(2)-3.el10")
+  end
+
+  def test_parses_older_rhel7_style
+    assert_equal "2.02.180(2)",
+      LVM::LVM.parse_version("2.02.180(2)-RHEL7 (2018-07-20)")
+  end
+
+  def test_parses_plain_version_without_build_suffix
+    assert_equal "2.03.40", LVM::LVM.parse_version("2.03.40")
+  end
+
+  def test_returns_input_unchanged_when_unparseable
+    assert_equal "garbage", LVM::LVM.parse_version("garbage")
+  end
+
+  def test_handles_nil_input
+    assert_equal "", LVM::LVM.parse_version(nil)
+  end
+end


### PR DESCRIPTION
### Description

This change fixes LVM version parsing so we reliably derive the canonical attribute lookup key across older and newer output formats.

Specifically:

- Replaced fragile split-on-hyphen parsing with a dedicated parser method, LVM::LVM.parse_version.
- Ensured parsing works for:
  - classic format: `2.03.28(2)-RHEL10 (...)`
  - RHEL 10 inline distro format: `2.03.32(2-RHEL10) (...)`
  - release suffix format: `2.03.32(2)-3.el10`
  - plain version: `2.03.40`
  - nil and unparseable inputs (safe fallback behavior)
- Updated version to use the parser method.
- Added unit tests covering all of the above cases.

### Issues Resolved

- Resolves sous-chefs/chef-ruby-lvm-attrib#90
- Related prior attempt: sous-chefs/chef-ruby-lvm#15

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG
